### PR TITLE
Enable CORS layer and add deflate tests

### DIFF
--- a/crates/data/src/compression.rs
+++ b/crates/data/src/compression.rs
@@ -3,14 +3,15 @@ use flate2::write::DeflateEncoder;
 use flate2::Compression;
 use std::io::prelude::*;
 
-pub fn deflate(data: String) -> Option<String> {
-    // Create a ZlibEncoder
-    let mut encoder = DeflateEncoder::new(Vec::new(), Compression::default());
+fn deflate_with_encoder<W: Write + AsRef<[u8]>>(
+    data: String,
+    mut encoder: DeflateEncoder<W>,
+) -> Option<String> {
+    // Create a DeflateEncoder
 
     // Write the JSON string into the encoder
-    match encoder.write_all(data.as_bytes()) {
-        Ok(_) => (),
-        Err(_) => return None,
+    if encoder.write_all(data.as_bytes()).is_err() {
+        return None;
     }
 
     // Finish the encoding process
@@ -21,4 +22,62 @@ pub fn deflate(data: String) -> Option<String> {
 
     // Convert the byte array to base64
     Some(base64::engine::general_purpose::STANDARD.encode(encoded_bytes))
+}
+
+pub fn deflate(data: String) -> Option<String> {
+    deflate_with_encoder(
+        data,
+        DeflateEncoder::new(Vec::new(), Compression::default()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+    use flate2::read::DeflateDecoder;
+    use std::io::{self, Read, Write};
+
+    #[test]
+    fn deflate_compresses_data() {
+        let input = r#"{"key":"value"}"#.to_string();
+        let encoded = deflate(input.clone()).expect("compression should succeed");
+
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .expect("base64 decode should succeed");
+
+        let mut decoder = DeflateDecoder::new(&decoded[..]);
+        let mut output = String::new();
+        decoder
+            .read_to_string(&mut output)
+            .expect("decompression should succeed");
+
+        assert_eq!(output, input);
+    }
+
+    struct FailingWriter;
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(io::ErrorKind::Other, "write error"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl AsRef<[u8]> for FailingWriter {
+        fn as_ref(&self) -> &[u8] {
+            &[]
+        }
+    }
+
+    #[test]
+    fn deflate_returns_none_on_error() {
+        let encoder = DeflateEncoder::new(FailingWriter, Compression::default());
+        let result = deflate_with_encoder("data".into(), encoder);
+        assert!(result.is_none());
+    }
 }

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -33,7 +33,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let app = Router::new()
         .route("/api/schedule", get(endpoints::schedule::get))
         .route("/api/schedule/next", get(endpoints::schedule::get_next))
-        .route("/api/health", get(endpoints::health::check));
+        .route("/api/health", get(endpoints::health::check))
+        .layer(cors_layer()?);
 
     let listener = TcpListener::bind(addr).await?;
 


### PR DESCRIPTION
## Summary
- apply CORS middleware in API router
- clarify compression documentation and refactor to allow testing
- add unit tests for deflate success and failure

## Testing
- `cargo test -p data`
- `cargo test -p api`


------
https://chatgpt.com/codex/tasks/task_e_688e2049e534832f8c29f5448913e210